### PR TITLE
Fix travis pipeline for PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ scala:
 - 2.12.8
 - 2.13.0
 before_install:
-- openssl aes-256-cbc -K $encrypted_4bc7aeb7f96e_key -iv $encrypted_4bc7aeb7f96e_iv
-  -in secrets.tar.enc -out secrets.tar -d
-- tar xvf secrets.tar
+- bash scripts/decrypt_files_if_not_pr.sh
 before_cache:
 - du -h -d 1 $HOME/.ivy2/
 - du -h -d 2 $HOME/.sbt/

--- a/scripts/decrypt_files_if_not_pr.sh
+++ b/scripts/decrypt_files_if_not_pr.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+if [[ "$TRAVIS_PULL_REQUEST" == "false" ]]; then
+    openssl aes-256-cbc -K $encrypted_4bc7aeb7f96e_key -iv $encrypted_4bc7aeb7f96e_iv -in secrets.tar.enc -out secrets.tar -d
+    tar xvf secrets.tar
+fi


### PR DESCRIPTION
Travis security policy is to not allow accessing secret variables during pull requests builds. Any attempt to do that will result in a failed build. So it is much better to just skip decrypting and let tests run.