### PR TITLE
depend on scala macro dependencies in Provided scope

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -81,6 +81,6 @@ lazy val publishSettings = ossPublishSettings ++ Seq(
 )
 
 lazy val scalaMacroDependencies: Seq[Setting[_]] = Seq(
-  libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-  libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value
+  libraryDependencies += "org.scala-lang" % "scala-reflect" % scalaVersion.value % Provided,
+  libraryDependencies += "org.scala-lang" % "scala-compiler" % scalaVersion.value % Provided
 )


### PR DESCRIPTION
This library seems to pull in the scala-compiler jar into the run-time classpath for every library that uses magnolia. 