### PR TITLE
broken tests fix #19 replace applicative => functor

### DIFF
--- a/tests/src/main/scala/tests.scala
+++ b/tests/src/main/scala/tests.scala
@@ -25,7 +25,7 @@ import scala.language.higherKinds
 object Tests {
   
   def main(args: Array[String]): Unit = {
-    applicative[Option]
+    functor[Option]
     monadic[({ type L[W] = Either[String, W] })#L]
     filterable[Seq]
 


### PR DESCRIPTION
Current [master build fails](https://travis-ci.org/github/propensive/mercator/jobs/634384645) with:
```scala
[error] /home/travis/build/propensive/mercator/tests/src/main/scala/tests.scala:28:5: not found: value applicative
[error]     applicative[Option]
```

This is problematic [for other contributors](https://github.com/propensive/mercator/pull/20#issuecomment-616777823) as well.

Changes here  resolve #19 